### PR TITLE
Pass EVSC along with the next task

### DIFF
--- a/app/app.gen.go
+++ b/app/app.gen.go
@@ -30,6 +30,15 @@ const (
 	Healthy   AppHealthReportItemStatus = "healthy"
 )
 
+// Defines values for EnvironmentVariableType.
+const (
+	Certificate EnvironmentVariableType = "certificate"
+	PrivateKey  EnvironmentVariableType = "private_key"
+	PublicKey   EnvironmentVariableType = "public_key"
+	Secret      EnvironmentVariableType = "secret"
+	Variable    EnvironmentVariableType = "variable"
+)
+
 // Defines values for ErrorResponseStatus.
 const (
 	ErrorResponseStatusError ErrorResponseStatus = "error"
@@ -124,6 +133,21 @@ type AppRequest struct {
 	Version string `json:"version"`
 }
 
+// EnvironmentVariable defines model for EnvironmentVariable.
+type EnvironmentVariable struct {
+	// Name The name of the environment variable.
+	Name string `json:"name"`
+
+	// Type The type of environment variable.
+	Type EnvironmentVariableType `json:"type"`
+
+	// Value The value of the environment variable.
+	Value string `json:"value"`
+}
+
+// EnvironmentVariableType The type of environment variable.
+type EnvironmentVariableType string
+
 // ErrorResponse defines model for ErrorResponse.
 type ErrorResponse struct {
 	// Error Error message detailing the failure.
@@ -140,6 +164,9 @@ type ErrorResponseStatus string
 type ExecuteResourceActionRequest struct {
 	// Action The action to perform on the resource.
 	Action string `json:"action"`
+
+	// EnvironmentVariables The environment variables for the operation.
+	EnvironmentVariables *[]EnvironmentVariable `json:"environment_variables,omitempty"`
 
 	// Input The input parameters for the operation.
 	Input *map[string]interface{} `json:"input,omitempty"`
@@ -163,6 +190,9 @@ type ExecuteResourceActionResponse struct {
 
 // ExecuteResourceOperationRequest defines model for ExecuteResourceOperationRequest.
 type ExecuteResourceOperationRequest struct {
+	// EnvironmentVariables The environment variables for the operation.
+	EnvironmentVariables *[]EnvironmentVariable `json:"environment_variables,omitempty"`
+
 	// Input The input parameters for the operation.
 	Input *map[string]interface{} `json:"input,omitempty"`
 

--- a/app/app.yaml
+++ b/app/app.yaml
@@ -324,6 +324,11 @@ components:
         input:
           type: object
           description: The input parameters for the operation.
+        environment_variables:
+          type: array
+          description: The environment variables for the operation.
+          items:
+            $ref: "#/components/schemas/EnvironmentVariable"
         metadata:
           type: object
           description: Metadata associated with the resource operation.
@@ -402,6 +407,11 @@ components:
         input:
           type: object
           description: The input parameters for the operation.
+        environment_variables:
+          type: array
+          description: The environment variables for the operation.
+          items:
+            $ref: "#/components/schemas/EnvironmentVariable"
       required:
         - request_type
         - resource
@@ -419,6 +429,24 @@ components:
       required:
         - response_type
         - output
+
+    EnvironmentVariable:
+      type: object
+      properties:
+        name:
+          type: string
+          description: The name of the environment variable.
+        value:
+          type: string
+          description: The value of the environment variable.
+        type:
+          type: string
+          description: The type of environment variable.
+          enum: [variable, secret, certificate, private_key, public_key]
+      required:
+        - name
+        - value
+        - type
 
     Resource:
       type: object


### PR DESCRIPTION
This PR adds environment variables to the `/apps.operations.next` response.